### PR TITLE
Rename Stock pages to Terima TTPB

### DIFF
--- a/resources/views/blower/stock.blade.php
+++ b/resources/views/blower/stock.blade.php
@@ -1,9 +1,9 @@
-@section('title', __('Blower Stock'))
-<x-layouts.app :title="__('Blower Stock')">
+@section('title', __('Blower Terima TTPB'))
+<x-layouts.app :title="__('Blower Terima TTPB')">
 
 <div class="card">
     <div class="card-header">
-        <h5 class="card-title mb-0">{{ __('Stock') }}</h5>
+        <h5 class="card-title mb-0">{{ __('Terima TTPB') }}</h5>
     </div>
     <div class="card-body">
 @include('partials.month-filter')

--- a/resources/views/components/layouts/menu/vertical.blade.php
+++ b/resources/views/components/layouts/menu/vertical.blade.php
@@ -31,7 +31,7 @@
             </a>
             <ul class="menu-sub">
               <li class="menu-item {{ request()->routeIs('gudang.stock') ? 'active' : '' }}">
-                <a class="menu-link" href="{{ route('gudang.stock') }}" wire:navigate>Stock</a>
+                <a class="menu-link" href="{{ route('gudang.stock') }}" wire:navigate>Terima TTPB</a>
               </li>
               <li class="menu-item {{ request()->routeIs('gudang.monitoring') ? 'active' : '' }}">
                 <a class="menu-link" href="{{ route('gudang.monitoring') }}" wire:navigate>Monitoring</a>
@@ -51,7 +51,7 @@
             </a>
             <ul class="menu-sub">
               <li class="menu-item {{ request()->routeIs('pencucian.stock') ? 'active' : '' }}">
-                <a class="menu-link" href="{{ route('pencucian.stock') }}" wire:navigate>Stock</a>
+                <a class="menu-link" href="{{ route('pencucian.stock') }}" wire:navigate>Terima TTPB</a>
               </li>
               <li class="menu-item {{ request()->routeIs('pencucian.monitoring') ? 'active' : '' }}">
                 <a class="menu-link" href="{{ route('pencucian.monitoring') }}" wire:navigate>Monitoring</a>
@@ -71,7 +71,7 @@
             </a>
             <ul class="menu-sub">
               <li class="menu-item {{ request()->routeIs('pengeringan.stock') ? 'active' : '' }}">
-                <a class="menu-link" href="{{ route('pengeringan.stock') }}" wire:navigate>Stock</a>
+                <a class="menu-link" href="{{ route('pengeringan.stock') }}" wire:navigate>Terima TTPB</a>
               </li>
               <li class="menu-item {{ request()->routeIs('pengeringan.monitoring') ? 'active' : '' }}">
                 <a class="menu-link" href="{{ route('pengeringan.monitoring') }}" wire:navigate>Monitoring</a>
@@ -91,7 +91,7 @@
             </a>
             <ul class="menu-sub">
               <li class="menu-item {{ request()->routeIs('blower.stock') ? 'active' : '' }}">
-                <a class="menu-link" href="{{ route('blower.stock') }}" wire:navigate>Stock</a>
+                <a class="menu-link" href="{{ route('blower.stock') }}" wire:navigate>Terima TTPB</a>
               </li>
               <li class="menu-item {{ request()->routeIs('blower.monitoring') ? 'active' : '' }}">
                 <a class="menu-link" href="{{ route('blower.monitoring') }}" wire:navigate>Monitoring</a>
@@ -111,7 +111,7 @@
             </a>
             <ul class="menu-sub">
               <li class="menu-item {{ request()->routeIs('mixing.stock') ? 'active' : '' }}">
-                <a class="menu-link" href="{{ route('mixing.stock') }}" wire:navigate>Stock</a>
+                <a class="menu-link" href="{{ route('mixing.stock') }}" wire:navigate>Terima TTPB</a>
               </li>
               <li class="menu-item {{ request()->routeIs('mixing.monitoring') ? 'active' : '' }}">
                 <a class="menu-link" href="{{ route('mixing.monitoring') }}" wire:navigate>Monitoring</a>
@@ -157,7 +157,7 @@
             </a>
             <ul class="menu-sub">
               <li class="menu-item {{ request()->routeIs('packaging.stock') ? 'active' : '' }}">
-                <a class="menu-link" href="{{ route('packaging.stock') }}" wire:navigate>Stock</a>
+                <a class="menu-link" href="{{ route('packaging.stock') }}" wire:navigate>Terima TTPB</a>
               </li>
               <li class="menu-item {{ request()->routeIs('packaging.monitoring') ? 'active' : '' }}">
                 <a class="menu-link" href="{{ route('packaging.monitoring') }}" wire:navigate>Monitoring</a>
@@ -177,7 +177,7 @@
             </a>
             <ul class="menu-sub">
               <li class="menu-item {{ request()->routeIs('finish_good.stock') ? 'active' : '' }}">
-                <a class="menu-link" href="{{ route('finish_good.stock') }}" wire:navigate>Stock</a>
+                <a class="menu-link" href="{{ route('finish_good.stock') }}" wire:navigate>Terima TTPB</a>
               </li>
               <li class="menu-item {{ request()->routeIs('finish_good.monitoring') ? 'active' : '' }}">
                 <a class="menu-link" href="{{ route('finish_good.monitoring') }}" wire:navigate>Monitoring</a>
@@ -199,7 +199,7 @@
             </a>
             <ul class="menu-sub">
               <li class="menu-item {{ request()->routeIs('gudang.stock') ? 'active' : '' }}">
-                <a class="menu-link" href="{{ route('gudang.stock') }}" wire:navigate>Stock</a>
+                <a class="menu-link" href="{{ route('gudang.stock') }}" wire:navigate>Terima TTPB</a>
               </li>
               <li class="menu-item {{ request()->routeIs('gudang.monitoring') ? 'active' : '' }}">
                 <a class="menu-link" href="{{ route('gudang.monitoring') }}" wire:navigate>Monitoring</a>
@@ -221,7 +221,7 @@
             </a>
             <ul class="menu-sub">
               <li class="menu-item {{ request()->routeIs('pencucian.stock') ? 'active' : '' }}">
-                <a class="menu-link" href="{{ route('pencucian.stock') }}" wire:navigate>Stock</a>
+                <a class="menu-link" href="{{ route('pencucian.stock') }}" wire:navigate>Terima TTPB</a>
               </li>
               <li class="menu-item {{ request()->routeIs('pencucian.monitoring') ? 'active' : '' }}">
                 <a class="menu-link" href="{{ route('pencucian.monitoring') }}" wire:navigate>Monitoring</a>
@@ -243,7 +243,7 @@
             </a>
             <ul class="menu-sub">
               <li class="menu-item {{ request()->routeIs('pengeringan.stock') ? 'active' : '' }}">
-                <a class="menu-link" href="{{ route('pengeringan.stock') }}" wire:navigate>Stock</a>
+                <a class="menu-link" href="{{ route('pengeringan.stock') }}" wire:navigate>Terima TTPB</a>
               </li>
               <li class="menu-item {{ request()->routeIs('pengeringan.monitoring') ? 'active' : '' }}">
                 <a class="menu-link" href="{{ route('pengeringan.monitoring') }}" wire:navigate>Monitoring</a>
@@ -265,7 +265,7 @@
             </a>
             <ul class="menu-sub">
               <li class="menu-item {{ request()->routeIs('blower.stock') ? 'active' : '' }}">
-                <a class="menu-link" href="{{ route('blower.stock') }}" wire:navigate>Stock</a>
+                <a class="menu-link" href="{{ route('blower.stock') }}" wire:navigate>Terima TTPB</a>
               </li>
               <li class="menu-item {{ request()->routeIs('blower.monitoring') ? 'active' : '' }}">
                 <a class="menu-link" href="{{ route('blower.monitoring') }}" wire:navigate>Monitoring</a>
@@ -287,7 +287,7 @@
             </a>
             <ul class="menu-sub">
               <li class="menu-item {{ request()->routeIs('mixing.stock') ? 'active' : '' }}">
-                <a class="menu-link" href="{{ route('mixing.stock') }}" wire:navigate>Stock</a>
+                <a class="menu-link" href="{{ route('mixing.stock') }}" wire:navigate>Terima TTPB</a>
               </li>
               <li class="menu-item {{ request()->routeIs('mixing.monitoring') ? 'active' : '' }}">
                 <a class="menu-link" href="{{ route('mixing.monitoring') }}" wire:navigate>Monitoring</a>
@@ -312,7 +312,7 @@
             </a>
             <ul class="menu-sub">
               <li class="menu-item {{ request()->routeIs('grinding.stock') ? 'active' : '' }}">
-                <a class="menu-link" href="{{ route('grinding.stock') }}" wire:navigate>Stock</a>
+                <a class="menu-link" href="{{ route('grinding.stock') }}" wire:navigate>Terima TTPB</a>
               </li>
               <li class="menu-item {{ request()->routeIs('grinding.monitoring') ? 'active' : '' }}">
                 <a class="menu-link" href="{{ route('grinding.monitoring') }}" wire:navigate>Monitoring</a>
@@ -337,7 +337,7 @@
             </a>
             <ul class="menu-sub">
               <li class="menu-item {{ request()->routeIs('packaging.stock') ? 'active' : '' }}">
-                <a class="menu-link" href="{{ route('packaging.stock') }}" wire:navigate>Stock</a>
+                <a class="menu-link" href="{{ route('packaging.stock') }}" wire:navigate>Terima TTPB</a>
               </li>
               <li class="menu-item {{ request()->routeIs('packaging.monitoring') ? 'active' : '' }}">
                 <a class="menu-link" href="{{ route('packaging.monitoring') }}" wire:navigate>Monitoring</a>
@@ -359,7 +359,7 @@
             </a>
             <ul class="menu-sub">
               <li class="menu-item {{ request()->routeIs('finish_good.stock') ? 'active' : '' }}">
-                <a class="menu-link" href="{{ route('finish_good.stock') }}" wire:navigate>Stock</a>
+                <a class="menu-link" href="{{ route('finish_good.stock') }}" wire:navigate>Terima TTPB</a>
               </li>
               <li class="menu-item {{ request()->routeIs('finish_good.monitoring') ? 'active' : '' }}">
                 <a class="menu-link" href="{{ route('finish_good.monitoring') }}" wire:navigate>Monitoring</a>

--- a/resources/views/finish_good/stock.blade.php
+++ b/resources/views/finish_good/stock.blade.php
@@ -1,9 +1,9 @@
-@section('title', __('Finish good Stock'))
-<x-layouts.app :title="__('Finish good Stock')">
+@section('title', __('Finish good Terima TTPB'))
+<x-layouts.app :title="__('Finish good Terima TTPB')">
 
 <div class="card">
     <div class="card-header">
-        <h5 class="card-title mb-0">{{ __('Stock') }}</h5>
+        <h5 class="card-title mb-0">{{ __('Terima TTPB') }}</h5>
     </div>
     <div class="card-body">
 @include('partials.month-filter')

--- a/resources/views/grinding/stock.blade.php
+++ b/resources/views/grinding/stock.blade.php
@@ -1,5 +1,5 @@
-@section('title', __('Grinding Stock'))
-<x-layouts.app :title="__('Grinding Stock')">
+@section('title', __('Grinding Terima TTPB'))
+<x-layouts.app :title="__('Grinding Terima TTPB')">
 
 <div class="card">
     <div class="card-header">

--- a/resources/views/gudang/stock.blade.php
+++ b/resources/views/gudang/stock.blade.php
@@ -1,9 +1,9 @@
-@section('title', __('Gudang Stock'))
-<x-layouts.app :title="__('Gudang Stock')">
+@section('title', __('Gudang Terima TTPB'))
+<x-layouts.app :title="__('Gudang Terima TTPB')">
 
 <div class="card">
     <div class="card-header">
-        <h5 class="card-title mb-0">{{ __('Stock') }}</h5>
+        <h5 class="card-title mb-0">{{ __('Terima TTPB') }}</h5>
     </div>
     <div class="card-body">
         <a href="{{ route('gudang.stock.create') }}" class="btn btn-primary mb-4">{{ __('Input BPG') }}</a>

--- a/resources/views/mixing/stock.blade.php
+++ b/resources/views/mixing/stock.blade.php
@@ -1,9 +1,9 @@
-@section('title', __('Mixing Stock'))
-<x-layouts.app :title="__('Mixing Stock')">
+@section('title', __('Mixing Terima TTPB'))
+<x-layouts.app :title="__('Mixing Terima TTPB')">
 
 <div class="card">
     <div class="card-header">
-        <h5 class="card-title mb-0">{{ __('Stock') }}</h5>
+        <h5 class="card-title mb-0">{{ __('Terima TTPB') }}</h5>
     </div>
     <div class="card-body">
 @include('partials.month-filter')

--- a/resources/views/monitoring-stock.blade.php
+++ b/resources/views/monitoring-stock.blade.php
@@ -1,8 +1,8 @@
-@section('title', __('Monitoring Stock'))
-<x-layouts.app :title="__('Monitoring Stock')">
+@section('title', __('Monitoring Terima TTPB'))
+<x-layouts.app :title="__('Monitoring Terima TTPB')">
 <div class="card">
     <div class="card-header">
-        <h5 class="card-title mb-0">{{ __('Ringkasan Stock') }}</h5>
+        <h5 class="card-title mb-0">{{ __('Ringkasan Terima TTPB') }}</h5>
     </div>
     <div class="card-body">
         <div class="table-responsive text-nowrap">

--- a/resources/views/packaging/stock.blade.php
+++ b/resources/views/packaging/stock.blade.php
@@ -1,9 +1,9 @@
-@section('title', __('Packaging Stock'))
-<x-layouts.app :title="__('Packaging Stock')">
+@section('title', __('Packaging Terima TTPB'))
+<x-layouts.app :title="__('Packaging Terima TTPB')">
 
 <div class="card">
     <div class="card-header">
-        <h5 class="card-title mb-0">{{ __('Stock') }}</h5>
+        <h5 class="card-title mb-0">{{ __('Terima TTPB') }}</h5>
     </div>
     <div class="card-body">
 @include('partials.month-filter')

--- a/resources/views/pencucian/stock.blade.php
+++ b/resources/views/pencucian/stock.blade.php
@@ -1,9 +1,9 @@
-@section('title', __('Pencucian Stock'))
-<x-layouts.app :title="__('Pencucian Stock')">
+@section('title', __('Pencucian Terima TTPB'))
+<x-layouts.app :title="__('Pencucian Terima TTPB')">
 
 <div class="card">
     <div class="card-header">
-        <h5 class="card-title mb-0">{{ __('Stock') }}</h5>
+        <h5 class="card-title mb-0">{{ __('Terima TTPB') }}</h5>
     </div>
     <div class="card-body">
 @include('partials.month-filter')

--- a/resources/views/pengeringan/stock.blade.php
+++ b/resources/views/pengeringan/stock.blade.php
@@ -1,9 +1,9 @@
-@section('title', __('Pengeringan Stock'))
-<x-layouts.app :title="__('Pengeringan Stock')">
+@section('title', __('Pengeringan Terima TTPB'))
+<x-layouts.app :title="__('Pengeringan Terima TTPB')">
 
 <div class="card">
     <div class="card-header">
-        <h5 class="card-title mb-0">{{ __('Stock') }}</h5>
+        <h5 class="card-title mb-0">{{ __('Terima TTPB') }}</h5>
     </div>
     <div class="card-body">
 @include('partials.month-filter')


### PR DESCRIPTION
## Summary
- Replace "Stock" labels with "Terima TTPB" across warehouse and process views
- Update navigation menu to link to "Terima TTPB" pages
- Adjust monitoring page headings to reference "Terima TTPB"

## Testing
- `php artisan test` *(fails: Failed opening required 'vendor/autoload.php')*

------
https://chatgpt.com/codex/tasks/task_e_689f113dce8883309064cb165403b486