### PR TITLE
Add Excel import/export buttons with role-specific TTPB export

### DIFF
--- a/app/Http/Controllers/TtpbController.php
+++ b/app/Http/Controllers/TtpbController.php
@@ -193,7 +193,7 @@ class TtpbController extends Controller
         return redirect()->route("{$role}.ttpb.preview");
     }
 
-    public function export()
+    public function export(Request $request)
     {
         $columns = [
             'tanggal', 'no_ttpb', 'lot_number', 'nama_barang', 'qty_awal',
@@ -201,11 +201,18 @@ class TtpbController extends Controller
             'coly', 'spec', 'keterangan', 'dari', 'ke',
         ];
 
-        $rows = Ttpb::all()
+        $query = Ttpb::query();
+        if ($role = $request->query('role')) {
+            $query->where('dari', $role);
+        }
+
+        $rows = $query->get()
             ->map(fn ($record) => collect($record->toArray())->only($columns)->toArray())
             ->toArray();
 
-        return SimpleExcelWriter::streamDownload('ttpb.xlsx')
+        $filename = ($role ?? 'ttpb') . '.xlsx';
+
+        return SimpleExcelWriter::streamDownload($filename)
             ->addRows($rows)
             ->toBrowser();
     }

--- a/resources/views/gudang/stock.blade.php
+++ b/resources/views/gudang/stock.blade.php
@@ -7,6 +7,16 @@
     </div>
     <div class="card-body">
         <a href="{{ route('gudang.stock.create') }}" class="btn btn-primary mb-4">{{ __('Input BPG') }}</a>
+
+        <div class="d-flex flex-wrap gap-2 mb-4">
+            <a href="{{ route('bpg.export') }}" class="btn btn-success">{{ __('Export') }}</a>
+            <form action="{{ route('bpg.import') }}" method="POST" enctype="multipart/form-data" class="d-flex gap-2">
+                @csrf
+                <input type="file" name="file" class="form-control" required>
+                <button type="submit" class="btn btn-secondary">{{ __('Import') }}</button>
+            </form>
+        </div>
+
         @include('partials.month-filter')
         <div class="table-responsive text-nowrap">
             <table class="table table-striped table-bordered">

--- a/resources/views/ttpb/index.blade.php
+++ b/resources/views/ttpb/index.blade.php
@@ -7,6 +7,16 @@
     </div>
     <div class="card-body">
         <a href="{{ route($role.'.ttpb.create') }}" class="btn btn-primary mb-4">{{ __('Isi TTPB') }}</a>
+
+        <div class="d-flex flex-wrap gap-2 mb-4">
+            <a href="{{ route('ttpb.export', ['role' => $role]) }}" class="btn btn-success">{{ __('Export') }}</a>
+            <form action="{{ route('ttpb.import') }}" method="POST" enctype="multipart/form-data" class="d-flex gap-2">
+                @csrf
+                <input type="file" name="file" class="form-control" required>
+                <button type="submit" class="btn btn-secondary">{{ __('Import') }}</button>
+            </form>
+        </div>
+
         <div class="table-responsive text-nowrap">
             <table class="table table-striped table-bordered">
                 <thead>


### PR DESCRIPTION
## Summary
- Add import and export buttons on Gudang stock and TTPB pages
- Support role-filtered TTPB exports with dynamic filenames

## Testing
- `php artisan test`

------
https://chatgpt.com/codex/tasks/task_e_68c1761682f08330926474a74dc98364